### PR TITLE
[mv3] Use enabled manifest.json rulesets during extension installation

### DIFF
--- a/platform/mv3/extension/js/ruleset-manager.js
+++ b/platform/mv3/extension/js/ruleset-manager.js
@@ -428,7 +428,7 @@ async function updateDynamicRules() {
 /******************************************************************************/
 
 async function defaultRulesetsFromLanguage() {
-    const out = [ 'default' ];
+    const out = await dnr.getEnabledRulesets();
 
     const dropCountry = lang => {
         const pos = lang.indexOf('-');


### PR DESCRIPTION
During the installation of the extension, the `defaultRulesetsFromLanguage` function uses a hard-coded `out` containing only the hard-coded default ruleset, so any enabled ruleset from the manifest.json other than "default" and the language default is being disabled during installation

This PR allows determining enabled rulesets before installing the extension on multiple browsers automatically